### PR TITLE
[Feat] 딜러는 2카드의 합계 점수가 16점 이하이면 반드시 1장을 추가로 뽑고, 17점 이상이면 추가할 수 없다.

### DIFF
--- a/src/main/java/oop/blackjackv2/domain/Card.java
+++ b/src/main/java/oop/blackjackv2/domain/Card.java
@@ -44,6 +44,10 @@ public class Card {
         return Pattern.values()[idx % PATTERNS_SIZE];
     }
 
+    public int getPoint() {
+        return denomination.getPoint();
+    }
+
 
     private enum Pattern {
         SPADE("spade"),
@@ -87,6 +91,10 @@ public class Card {
 
         public String getMark() {
             return mark;
+        }
+
+        public int getPoint() {
+            return point;
         }
     }
 }

--- a/src/main/java/oop/blackjackv2/domain/Dealer.java
+++ b/src/main/java/oop/blackjackv2/domain/Dealer.java
@@ -8,6 +8,8 @@ public class Dealer implements Person {
     private CardDeck cardDeck;
     private List<Card> myCards = new LinkedList<>();
 
+    private final int POINT_LIMIT = 16;
+
     public Dealer(CardDeck cardDeck){
         this.cardDeck = cardDeck;
     }
@@ -15,6 +17,21 @@ public class Dealer implements Person {
     @Override
     public void initDraw() {
         addToMine(this.cardDeck.draw());
+    }
+
+    @Override
+    public void draw() {
+        if (getPoints() <= POINT_LIMIT) {
+            addToMine(this.cardDeck.draw());
+        } else {
+            System.out.println("딜러는 17점 이상이므로 카드를 뽑지 않습니다.");
+        }
+    }
+
+    private int getPoints() {
+        return myCards.stream()
+                .mapToInt(Card::getPoint)
+                .sum();
     }
 
     private void addToMine(Card card) {

--- a/src/main/java/oop/blackjackv2/domain/Dealer.java
+++ b/src/main/java/oop/blackjackv2/domain/Dealer.java
@@ -21,11 +21,15 @@ public class Dealer implements Person {
 
     @Override
     public void draw() {
-        if (getPoints() <= POINT_LIMIT) {
+        if (canDraw()) {
             addToMine(this.cardDeck.draw());
         } else {
             System.out.println("딜러는 17점 이상이므로 카드를 뽑지 않습니다.");
         }
+    }
+
+    private boolean canDraw() {
+        return getPoints() <= POINT_LIMIT;
     }
 
     private int getPoints() {

--- a/src/main/java/oop/blackjackv2/domain/Gamer.java
+++ b/src/main/java/oop/blackjackv2/domain/Gamer.java
@@ -18,6 +18,11 @@ public class Gamer implements Person {
         addToMine(this.cardDeck.draw());
     }
 
+    @Override
+    public void draw() {
+        addToMine(this.cardDeck.draw());
+    }
+
     private void addToMine(Card card) {
         this.myCards.add(card);
     }

--- a/src/main/java/oop/blackjackv2/domain/Person.java
+++ b/src/main/java/oop/blackjackv2/domain/Person.java
@@ -3,4 +3,6 @@ package oop.blackjackv2.domain;
 public interface Person {
 
     void initDraw();
+
+    void draw();
 }

--- a/src/test/java/oop/blackjackv2/domain/DealerTest.java
+++ b/src/test/java/oop/blackjackv2/domain/DealerTest.java
@@ -3,6 +3,7 @@ package oop.blackjackv2.domain;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 class DealerTest {
@@ -26,6 +27,25 @@ class DealerTest {
 
         // then
         assertThat(dealer.getMyCards()).hasSize(1);
+    }
+
+
+    @Test
+    @DisplayName("딜러가 16점 이상이면 카드를 더 뽑지 않는다.")
+    void dealerCanDraw(){
+        //given
+        cardDeck.createCards();
+
+        //when
+        dealer.initDraw();
+        dealer.initDraw();
+        dealer.draw();
+        dealer.draw();
+        dealer.draw();
+        dealer.draw();
+
+        //then
+        assertThat(dealer.getMyCards().stream().mapToInt(Card::getPoint).sum()).isGreaterThan(16);
     }
 
 


### PR DESCRIPTION
- 딜러와 게이머가 카드를 뽑기 위해서 "초기에 뽑아라"와는 다른 책임을 갖는 "뽑아라" 메시지를 수신하도록 추가
- 딜러는 카드를 뽑을 때, 제한 조건에 맞게 뽑을 수 있도록 추가.
- 조건식을 메서드화